### PR TITLE
Bump NGLPy version and patch version of TopoPy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ scipy>=1.3.2,<2.0
 numpy>=1.17.4,<2.0
 scikit-learn>=0.21.2,<1.0
 networkx>=2.4,<3.0
-nglpy>=1.0.6,<2.0
+nglpy>=1.1.0,<2.0

--- a/topopy/__init__.py
+++ b/topopy/__init__.py
@@ -24,4 +24,4 @@ __all__ = [
     "MergeTree",
     "ContourTree",
 ]
-__version__ = "1.0.1"
+__version__ = "1.0.2"


### PR DESCRIPTION
What?
=====

Keep TopoPy using the latest version available of NGLPy

Why?
====

I exposed a new class in NGLPy that should be automatically available
for people trying to use TopoPy. They should not have to hunt for the
correct version.

This should help with #37 by making it simpler to just pip install the latest topopy version and having the latest nglpy as well.